### PR TITLE
ci: add OpenAPI generation workflow

### DIFF
--- a/.github/workflows/generate-openapi.yml
+++ b/.github/workflows/generate-openapi.yml
@@ -1,0 +1,52 @@
+name: Generate OpenAPI JSON
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch: {}
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Generate OpenAPI JSON
+        run: |
+          python tools/generate_openapi.py
+
+      - name: Upload openapi.json artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi-json
+          path: openapi.json
+
+      - name: Commit openapi.json back to repo (optional)
+        if: github.actor != 'github-actions[bot]'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add openapi.json || true
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore(ci): update generated openapi.json [skip ci]" || true
+            git push origin HEAD:main || true
+          fi

--- a/README.md
+++ b/README.md
@@ -112,3 +112,28 @@ python -m ruff format .
 
 Pre-commit will automatically run configured linters (ruff, black, isort)
 on staged files.
+
+OpenAPI generation
+------------------
+
+This repository can generate an OpenAPI JSON document for the FastAPI app.
+
+Locally (PowerShell):
+
+```powershell
+# activate your venv first (see Running locally above)
+python tools/generate_openapi.py
+# the file will be written to openapi.json in the repo root
+```
+
+CI workflow
+----------
+
+A GitHub Actions workflow is included at `.github/workflows/generate-openapi.yml`.
+It runs on pushes to `main`, PRs against `main`, and manually via `workflow_dispatch`.
+
+- The workflow installs Python, runs `tools/generate_openapi.py`, and uploads the
+  generated `openapi.json` as an artifact named `openapi-json`.
+- Optionally the workflow attempts to commit `openapi.json` back to `main` when changed; if you prefer a PR-based flow I can update the workflow to open a pull request instead of pushing directly.
+
+Fetch the artifact from the workflow run UI (Actions → Choose run → Artifacts → openapi-json).

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,496 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "ai-agent API",
+    "description": "Lightweight AI agent example. Use `/v1/invoke` to run the agent, `/v1/invoke/stream` for streaming responses, and `/v1/tools` to inspect available tools.",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/v1/invoke": {
+      "post": {
+        "tags": [
+          "agent"
+        ],
+        "summary": "Invoke the agent synchronously",
+        "operationId": "invoke_v1_invoke_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InvokeRequest",
+                "examples": {
+                  "default": {
+                    "summary": "Example invoke",
+                    "value": {
+                      "input": "Summarize the following text: ..."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvokeResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/tools": {
+      "get": {
+        "tags": [
+          "tools"
+        ],
+        "summary": "List available tools",
+        "operationId": "list_tools_v1_tools_get",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToolsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/tools/{name}/run": {
+      "post": {
+        "tags": [
+          "tools"
+        ],
+        "summary": "Execute a named tool",
+        "operationId": "run_tool_v1_tools__name__run_post",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ToolRunRequest",
+                "examples": {
+                  "default": {
+                    "summary": "Example tool run",
+                    "value": {
+                      "input": "abc"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToolRunResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "tags": [
+          "agent"
+        ],
+        "summary": "Service health check",
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/invoke/stream": {
+      "post": {
+        "tags": [
+          "agent"
+        ],
+        "summary": "Invoke the agent with streaming (SSE)",
+        "operationId": "invoke_stream_v1_invoke_stream_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InvokeRequest",
+                "examples": {
+                  "default": {
+                    "summary": "Example invoke stream",
+                    "value": {
+                      "input": "Summarize the following text: ..."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Server-Sent Events streaming response with JSON payloads.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "HealthResponse": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status",
+            "example": "ok"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "title": "HealthResponse"
+      },
+      "InvokeRequest": {
+        "properties": {
+          "input": {
+            "type": "string",
+            "title": "Input",
+            "example": "Summarize the following text: ..."
+          },
+          "chat_history": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chat History",
+            "description": "Conversation history"
+          },
+          "tools": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tools",
+            "description": "Optional list of tool names to allow"
+          }
+        },
+        "type": "object",
+        "required": [
+          "input"
+        ],
+        "title": "InvokeRequest"
+      },
+      "InvokeResponse": {
+        "properties": {
+          "output": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Output",
+            "description": "Primary assistant output"
+          },
+          "used_tools": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Used Tools",
+            "description": "List of tools used"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata",
+            "description": "Runtime metadata"
+          }
+        },
+        "type": "object",
+        "title": "InvokeResponse"
+      },
+      "ToolRunRequest": {
+        "properties": {
+          "input": {
+            "title": "Input",
+            "example": "some input for the tool"
+          }
+        },
+        "type": "object",
+        "required": [
+          "input"
+        ],
+        "title": "ToolRunRequest"
+      },
+      "ToolRunResponse": {
+        "properties": {
+          "tool_name": {
+            "type": "string",
+            "title": "Tool Name",
+            "description": "Name of the tool invoked"
+          },
+          "result": {
+            "title": "Result",
+            "description": "Tool execution result"
+          }
+        },
+        "type": "object",
+        "required": [
+          "tool_name",
+          "result"
+        ],
+        "title": "ToolRunResponse"
+      },
+      "ToolsResponse": {
+        "properties": {
+          "tools": {
+            "items": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Tools",
+            "description": "Available tools"
+          }
+        },
+        "type": "object",
+        "required": [
+          "tools"
+        ],
+        "title": "ToolsResponse"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "agent",
+      "description": "Agent invocation and streaming endpoints."
+    },
+    {
+      "name": "tools",
+      "description": "Tool discovery and execution endpoints."
+    }
+  ]
+}

--- a/tools/generate_openapi.py
+++ b/tools/generate_openapi.py
@@ -1,0 +1,21 @@
+
+import json
+import sys
+from pathlib import Path
+
+# Ensure the project root is on sys.path so we can import the FastAPI app
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from api import app  # noqa: E402
+
+
+def main() -> None:
+    out = ROOT / "openapi.json"
+    data = app.openapi()
+    out.write_text(json.dumps(data, indent=2))
+    print(f"Wrote OpenAPI JSON to {out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add a GitHub Actions workflow to generate and upload openapi.json. The workflow runs on pushes to main, PRs, and manually. It installs Python, runs tools/generate_openapi.py, uploads the generated openapi.json as an artifact, and optionally commits the generated file back to main. Also updated README with instructions.