### PR TITLE
ci: upgrade Node (20.19.0) and fix ruff lint errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,8 @@ jobs:
       - name: Set up Node.js (for building web UI)
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          # Vite and some dev deps require Node >= 20.19.0
+          node-version: 20.19.0
 
       - name: Install and build web UI
         working-directory: ./webui

--- a/api.py
+++ b/api.py
@@ -309,7 +309,9 @@ async def logout(authorization: Optional[str] = LOGOUT_HEADER):
     removes it from the in-memory store if present.
     """
     if not authorization or not authorization.startswith("Bearer "):
-        raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
+        raise HTTPException(
+            status_code=401, detail="Missing or invalid Authorization header"
+        )
     token = authorization.split(" ", 1)[1]
     if token in _TOKENS:
         _TOKENS.pop(token, None)

--- a/api.py
+++ b/api.py
@@ -31,8 +31,12 @@ app = FastAPI(
 )
 
 # Serve static web UI when available (built via Docker multi-stage)
-if os.path.isdir('webui_dist'):
-    app.mount('/', StaticFiles(directory='webui_dist', html=True), name='webui')
+if os.path.isdir("webui_dist"):
+    app.mount(
+        "/",
+        StaticFiles(directory="webui_dist", html=True),
+        name="webui",
+    )
 
 # API auth token (runtime). For development put it in .env or docker-compose env_file.
 API_KEY = os.environ.get("AGENT_API_KEY")
@@ -129,6 +133,12 @@ INVOKE_STREAM_BODY = Body(
 )
 
 
+# Module-level Body/header constants for endpoints that otherwise would use
+# a function-call default (B008 lint).
+LOGIN_BODY = Body(...)
+LOGOUT_HEADER = Header(None)
+
+
 def get_executor():
     """Return a shared executor instance, building it lazily on first use.
 
@@ -157,7 +167,10 @@ def _serialize_tool(t: Any) -> Dict[str, str]:
     if isinstance(t, dict):
         return {"name": t.get("name"), "description": t.get("description")}
 
-    return {"name": getattr(t, "name", str(t)), "description": getattr(t, "description", "")}
+    return {
+        "name": getattr(t, "name", str(t)),
+        "description": getattr(t, "description", ""),
+    }
 
 
 def check_auth(authorization: Optional[str]):
@@ -265,8 +278,13 @@ async def list_tools(authorization: Optional[str] = Header(None)):
     return {"tools": tools}
 
 
-@app.post("/login", response_model=LoginResponse, tags=["agent"], summary="Login and get a session token")
-async def login(req: LoginRequest = Body(...)):
+@app.post(
+    "/login",
+    response_model=LoginResponse,
+    tags=["agent"],
+    summary="Login and get a session token",
+)
+async def login(req: LoginRequest = LOGIN_BODY):
     """Authenticate using username/password and return a temporary token.
 
     This simple endpoint is intended for development. In production, use an
@@ -278,8 +296,13 @@ async def login(req: LoginRequest = Body(...)):
     return _issue_token()
 
 
-@app.post("/logout", response_model=LogoutResponse, tags=["agent"], summary="Logout and revoke session token")
-async def logout(authorization: Optional[str] = Header(None)):
+@app.post(
+    "/logout",
+    response_model=LogoutResponse,
+    tags=["agent"],
+    summary="Logout and revoke session token",
+)
+async def logout(authorization: Optional[str] = LOGOUT_HEADER):
     """Revoke a previously issued session token.
 
     The endpoint looks for a Bearer token in the Authorization header and

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,11 +1,11 @@
 
 import time
 
-from fastapi.testclient import TestClient
 import pytest
+from fastapi.testclient import TestClient
 
 import api
-from api import ADMIN_PASS, ADMIN_USER, TOKEN_LIFETIME, _TOKENS, app
+from api import _TOKENS, ADMIN_PASS, ADMIN_USER, TOKEN_LIFETIME, app
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,8 +1,8 @@
 
 import time
 
-import pytest
 from fastapi.testclient import TestClient
+import pytest
 
 import api
 from api import ADMIN_PASS, ADMIN_USER, TOKEN_LIFETIME, _TOKENS, app

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,10 +1,11 @@
 
 import time
+
 import pytest
 from fastapi.testclient import TestClient
 
 import api
-from api import app, _TOKENS, TOKEN_LIFETIME, ADMIN_USER, ADMIN_PASS
+from api import ADMIN_PASS, ADMIN_USER, TOKEN_LIFETIME, _TOKENS, app
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Upgrade CI Node to 20.19.0 so Vite and dev deps can build; apply ruff fixes in api.py and tests to satisfy linter.\n\nFiles changed: .github/workflows/ci.yml, api.py, tests/test_auth.py.